### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ jdk:
 before_script:
   - me.j360.disboot.websocket.echo "MAVEN_OPTS='-Xmx1024m -XX:MaxPermSize=256m'" > ~/.mavenrc
 after_success:
-  - mvn clean cobertura:cobertura
+  - mvn -T 1C clean cobertura:cobertura
   - bash <(curl -s https://codecov.io/bash)
-install: travis_wait 30 mvn install
+install: travis_wait 30 mvn -T 1C install

--- a/j360-disboot-websocket/pom.xml
+++ b/j360-disboot-websocket/pom.xml
@@ -24,7 +24,7 @@
         <dependency>
             <groupId>com.corundumstudio.socketio</groupId>
             <artifactId>netty-socketio</artifactId>
-            <version>1.7.18-SNAPSHOT</version>
+            <version>1.7.19</version>
         </dependency>
         <dependency>
             <groupId>io.socket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<?xml version="1.0" encoding="UTF-8"?><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>me.j360.disboot</groupId>
@@ -50,7 +47,9 @@
 
     <dependencyManagement>
         <dependencies>
-            <!--j360 framework-->
+            
+<!--j360 framework-->
+
             <dependency>
                 <groupId>me.j360.framework</groupId>
                 <artifactId>j360-core</artifactId>
@@ -424,7 +423,7 @@
                     <configuration>
                         <argLine>-Xdebug -Dspring.config.location=file:../.././yml/application-local.yml,file:../.././yml/application-sharding.yml,classpath:application.yml</argLine>
                     </configuration>
-                </plugin>
+                <configuration><parallel>all</parallel></configuration></plugin>
             </plugins>
         </pluginManagement>
         <plugins>


### PR DESCRIPTION

[Parallel builds in Maven 3](https://cwiki.apache.org/confluence/display/MAVEN/Parallel+builds+in+Maven+3) Maven 3.x has the capability to perform parallel builds.

According to [Minimize dynamic and snapshot versions](https://docs.gradle.org/current/userguide/performance.html#minimize_dynamic_and_snapshot_versions), we should avoid using snapshot versions. And a build configuration should always specify exact versions of external libraries to make a build reproduceable. A lack of exact versions can cause problems when new versions of a dependency become available in the future that might introduce incompatible changes.

According to [Maven parallel test](https://www.baeldung.com/maven-junit-parallel-tests), we can run tests in parallel.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
